### PR TITLE
Add a subgraph view to the publications details page

### DIFF
--- a/department-of-reuse/src/pages/Paper.vue
+++ b/department-of-reuse/src/pages/Paper.vue
@@ -130,8 +130,8 @@
   </div>
 </template>
 <script lang="ts">
-import cytoscape, { Core, CytoscapeOptions, NodeDefinition, EdgeDefinition, ElementsDefinition} from "cytoscape";
-import fcose from "cytoscape-fcose";
+import cytoscape, { CytoscapeOptions, NodeDefinition, EdgeDefinition, ElementsDefinition} from "cytoscape";
+import dagre from "cytoscape-dagre";
 
 import { defineComponent, onBeforeMount, ref, watch } from "vue";
 import { Author, Work, WorkMessage } from "../clients/crossref";
@@ -158,7 +158,6 @@ export default defineComponent({
   components: {  },
   setup() {
 
-    const cyInstance = ref<Core | null>(null);
     const graphData = ref<ElementsDefinition | null>(null);
 
     const isLoading = ref(false);
@@ -222,8 +221,8 @@ export default defineComponent({
       return  {
         container: document.getElementById('cyroot'),
         elements: graphData.value,
-        animate: true,
-        layout: { name: "fcose" },
+        animate: false,
+        layout: { name: "dagre", rankDir: 'TB', padding: 0, nodeDimensionsIncludeLabels: true, nodeSep: 10},
         style: [
           {
             selector: "node",
@@ -234,21 +233,23 @@ export default defineComponent({
               height: 10,
               "font-size": "8pt",
               "text-opacity": 1,
-              "text-valign": "center",
-              "text-halign": "right",
-              color: "#2c3e50"
             },
           },
           {
             selector: ".reused",
             style: {
-              "background-color": "#b31b1b"
+              "background-color": "#b31b1b",
+              "text-valign": "top",
+              "text-halign": "center",
             }
           },
           {
             selector: ".reusing",
             style: {
-              "background-color": "#238636"
+              "background-color": "#238636",
+              "text-valign": "bottom",
+              "text-halign": "center",
+              
             }
           },
           {
@@ -266,24 +267,25 @@ export default defineComponent({
             },
           },
           {
-            selector: "$node > node",
+            selector: ".current",
             style: {
-              "border-width": "2px",
-              "border-color": "#ff00ff",
-              "background-color": "#ff0000"
+              "border-width": "1px",
+              "border-color": "#000000",
+              "background-color": "#6fa8dc",
+              "text-valign": "center",
+              "text-halign": "right",
+              
             }
-          },
+          }
+        
         ],
       } as CytoscapeOptions;
     }
 
     function updateCyInstance() {
       if(graphData.value !== null){
-
         var cy = cytoscape(createCyConfig());
-        cyInstance.value = cy;
-
-        cy.layout({ name: "fcose" }).run();
+        cy.panningEnabled(false);
       }
     }
 
@@ -296,12 +298,9 @@ export default defineComponent({
         await loadPaper();
         
 
-      cytoscape.use(fcose);
+      cytoscape.use(dagre);
       
-      var cy = cytoscape(createCyConfig());
-      cyInstance.value = cy;
-
-      cy.layout({ name: "fcose" }).run();
+      updateCyInstance();
     });
 
     watch(

--- a/department-of-reuse/src/pages/Paper.vue
+++ b/department-of-reuse/src/pages/Paper.vue
@@ -28,13 +28,8 @@
             Published: {{ paper.message.created.dateTime.toLocaleDateString() }}
           </p>
         </div>
-        
-
       </div>
 
-      
-
-      
       <div class="grid grid-cols-2 gap-4 p-5">
         <div>
           <h2 class="text-l bg-opacity-40 bg-blue-200">Reused by</h2>
@@ -118,14 +113,8 @@
           </table>
 
           </div>
-
-          
-
         </div>
       </div>
-
-      
-
     </div>
   </div>
 </template>
@@ -157,7 +146,6 @@ export default defineComponent({
   name: "Paper",
   components: {  },
   setup() {
-
     const graphData = ref<ElementsDefinition | null>(null);
 
     const isLoading = ref(false);
@@ -289,18 +277,15 @@ export default defineComponent({
       }
     }
 
-
-
     onBeforeMount(async () => {
         const doiPrefix = router.currentRoute.value.params.doiPrefix as string;
         const doiSuffix = router.currentRoute.value.params.doiSuffix as string;
         doi.value = `${doiPrefix}/${doiSuffix}`;
         await loadPaper();
         
-
-      cytoscape.use(dagre);
+        cytoscape.use(dagre);
       
-      updateCyInstance();
+        updateCyInstance();
     });
 
     watch(


### PR DESCRIPTION
**Reason for this PR**
As said in #334 , we want to visualize the reusing / reused publications on the *Publication Details* page using a graph. The original plan was, in fact, to replace the current table based view altogether.

**Changes in this PR**
This PR adds a subgraph view to the *Publication Details* page that visualizes directly resuing publications as well as directly reused publications. I decided to not replace the table view, as they add some more information (including clickable links) that cannot fully be replaced be the graph (IMO).  Screenshots below illustrate the change:

![grafik](https://user-images.githubusercontent.com/37844219/185408733-2ca1d5db-8c9f-4d06-b4d2-2a2183aaf10c.png)

![grafik](https://user-images.githubusercontent.com/37844219/185408838-163c8328-4c20-4b65-802f-18d5bcf6c943.png)

Feel free to suggest different placements or designs for the subgraph view!

**Links**
Closes #334 